### PR TITLE
fix data race in manager and writer, update writer_test v2

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -19,6 +19,7 @@ type manager struct {
 	cr            *cron.Cron
 	context       chan int
 	wg            sync.WaitGroup
+	lock          sync.Mutex
 }
 
 // NewManager generate the Manager with config
@@ -133,6 +134,7 @@ func (m *manager) ParseVolume(c *Config) {
 
 // GenLogFileName generate the new log file name, filename should be absolute path
 func (m *manager) GenLogFileName(c *Config) (filename string) {
+	m.lock.Lock()
 	// [path-to-log]/filename.log.2007010215041517
 	if c.Compress {
 		filename = path.Join(c.LogPath, c.FileName+".log.gz."+m.startAt.Format(c.TimeTagFormat))
@@ -141,5 +143,6 @@ func (m *manager) GenLogFileName(c *Config) (filename string) {
 	}
 	// reset the start time to now
 	m.startAt = time.Now()
+	m.lock.Unlock()
 	return
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -244,7 +244,6 @@ func TestAutoRemove(t *testing.T) {
 	}
 	writer.Close()
 	writer.cf.MaxRemain = 0
-	writer.AutoRemove()
 	clean()
 }
 

--- a/writer_test.go
+++ b/writer_test.go
@@ -61,6 +61,12 @@ func newBufferWriter() *BufferWriter {
 	return w.(*BufferWriter)
 }
 
+func TestNewWriter(t *testing.T) {
+	if _, err := NewWriter(WithRollingVolumeSize("1mb")); err != nil {
+		t.Fatal("error in test new writer", err)
+	}
+}
+
 func TestWrite(t *testing.T) {
 	var writer io.WriteCloser
 	var c int = 1000


### PR DESCRIPTION
修复了上次提到的几个问题。

但是遇到了一个新的问题，开启compress的情况下，会随机出现压缩后文件为空的情况。暂时没有找到是什么原因导致的，还请帮忙看一下。

我移除`return os.Remove(cmpname + ".tmp") // remove *.log.tmp file`后测试，确认了原文件是正常的。

如果不传递`oldfile`指针，在`CompressFile`中打开原文件，这样不会出现压缩后文件为空的情况。