### PR TITLE
Close unclosed files

### DIFF
--- a/codelingo.yaml
+++ b/codelingo.yaml
@@ -1,3 +1,4 @@
 tenets:
 - import: codelingo/effective-go
 - import: codelingo/code-review-comments
+- import: codelingo/rfjakob-gocryptfs/missing-close-file

--- a/manager.go
+++ b/manager.go
@@ -65,6 +65,7 @@ func NewManager(c *Config) (Manager, error) {
 					if info, err := file.Stat(); err == nil && info.Size() > m.thresholdSize {
 						m.fire <- m.GenLogFileName(c)
 					}
+					file.Close()
 				}
 			}
 		}()

--- a/writer.go
+++ b/writer.go
@@ -142,6 +142,8 @@ func NewWriterFromConfigFile(path string) (RollingWriter, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer file.Close()
+
 	cfg := NewDefaultConfig()
 	buf, err := ioutil.ReadAll(file)
 	if err != nil {


### PR DESCRIPTION
Avoid resource leaks by closing files after they are used.

This issue was found using the [CodeLingo](https://www.codelingo.io) Tenet [missing-close-file](https://www.codelingo.io/tenets/codelingo/rfjakob-gocryptfs/missing-close-file) which I have added to the codelingo.yaml file at the root of the repo.