### PR TITLE
fix:the log is archived into the wrong file

### DIFF
--- a/rollingwriter.go
+++ b/rollingwriter.go
@@ -91,6 +91,9 @@ type Config struct {
 	BufferWriterThershould int `json:"buffer_thershould"`
 	// Compress will compress log file with gzip
 	Compress bool `json:"compress"`
+
+	// FilterEmptyBackup will not backup empty file if you set it true
+	FilterEmptyBackup bool `json:"filter_empty_backup"`
 }
 
 // NewDefaultConfig return the default config

--- a/writer.go
+++ b/writer.go
@@ -340,19 +340,17 @@ func (w *AsynchronousWriter) Write(b []byte) (int, error) {
 				if err := w.Reopen(filename); err != nil {
 					return 0, err
 				}
+			case err := <-w.errChan:
+				// NOTE this error caused by last write maybe ignored
+				return 0, err
+
 			default:
 				ok = true
 			}
 		}
 
-		select {
-		case err := <-w.errChan:
-			// NOTE this error caused by last write maybe ignored
-			return 0, err
-		default:
-			w.queue <- append(_asyncBufferPool.Get().([]byte)[0:0], b...)[:len(b)]
-			return len(b), nil
-		}
+		w.queue <- append(_asyncBufferPool.Get().([]byte)[0:0], b...)[:len(b)]
+		return len(b), nil
 	}
 	return 0, ErrClosed
 }


### PR DESCRIPTION
当长时间没有日志写入的时候，后续的前几条日志易被归档到错误的文件中。
针对上诉问题，做了一下修复。同时，配置文件中新增了FilterEmptyBackup参数，来控制是否需要对空的文件进行备份操作。
