### PR TITLE
Fix Issue #47

### DIFF
--- a/rollingwriter.go
+++ b/rollingwriter.go
@@ -108,6 +108,7 @@ type Config struct {
 	// AsyncWriterModeBufferSize only works when WriterMode is 3(async).
 	// For the thread-safe purpose, we need to make a copy of input bytes when AsynchronousWriter#Write calls.
 	// By default, the buffer size is 1 KB.
+	// Be careful, each time set a AsyncWriterModeBufferSize with WriterMode equals to 3, will override the pool#New method.
 	AsyncWriterModeBufferSize int `json:"async_writer_mode_buffer_size"`
 }
 

--- a/rollingwriter.go
+++ b/rollingwriter.go
@@ -104,12 +104,6 @@ type Config struct {
 
 	// FilterEmptyBackup will not backup empty file if you set it true
 	FilterEmptyBackup bool `json:"filter_empty_backup"`
-
-	// AsyncWriterModeBufferSize only works when WriterMode is 3(async).
-	// For the thread-safe purpose, we need to make a copy of input bytes when AsynchronousWriter#Write calls.
-	// By default, the buffer size is 1 KB.
-	// Be careful, each time set a AsyncWriterModeBufferSize with WriterMode equals to 3, will override the pool#New method.
-	AsyncWriterModeBufferSize int `json:"async_writer_mode_buffer_size"`
 }
 
 func (c *Config) fileFormat(start time.Time) (filename string) {

--- a/rollingwriter.go
+++ b/rollingwriter.go
@@ -17,8 +17,8 @@ const (
 )
 
 var (
-	// BufferSize defined the buffer size, by default 1M buffer will be allocate
-	BufferSize = 0x100000
+	// BufferSize defined the buffer size, by default 1 KB buffer will be allocated
+	BufferSize = 1024
 	// QueueSize defined the queue size for asynchronize write
 	QueueSize = 1024
 	// Precision defined the precision about the reopen operation condition
@@ -104,6 +104,11 @@ type Config struct {
 
 	// FilterEmptyBackup will not backup empty file if you set it true
 	FilterEmptyBackup bool `json:"filter_empty_backup"`
+
+	// AsyncWriterModeBufferSize only works when WriterMode is 3(async).
+	// For the thread-safe purpose, we need to make a copy of input bytes when AsynchronousWriter#Write calls.
+	// By default, the buffer size is 1 KB.
+	AsyncWriterModeBufferSize int `json:"async_writer_mode_buffer_size"`
 }
 
 func (c *Config) fileFormat(start time.Time) (filename string) {

--- a/writer.go
+++ b/writer.go
@@ -146,11 +146,6 @@ func NewWriterFromConfig(c *Config) (RollingWriter, error) {
 			Writer: writer,
 		}
 	case "async":
-		if c.AsyncWriterModeBufferSize > 0 {
-			_asyncBufferPool.New = func() interface{} {
-				return make([]byte, c.AsyncWriterModeBufferSize)
-			}
-		}
 		wr := &AsynchronousWriter{
 			ctx:     make(chan int),
 			queue:   make(chan []byte, QueueSize),


### PR DESCRIPTION
decrease asyncBufferPool's object initial size from 1MB to 1KB, also provide an option for adjustment.

to distinguish from BufferedWriter, move _asyncBufferPool as AsynchronousWriter's field.